### PR TITLE
updating `set_frequency` to include fine tune frequency

### DIFF
--- a/itla/itla12.py
+++ b/itla/itla12.py
@@ -348,7 +348,7 @@ class ITLA12(ITLABase):
                 try:
                     self.set_fine_tuning(0)
                 except ExecutionError:
-                    sleep(self.default_sleep_time)
+                    sleep(self.sleep_time)
                 except CPException:
                     self.wait()
                     break

--- a/itla/itla12.py
+++ b/itla/itla12.py
@@ -664,6 +664,18 @@ class ITLA12(ITLABase):
 
         return ftf * 1e-3
 
+    def get_ftf_range(self):
+        """
+        Return the maximum and minimum off grid tuning for the laser's frequency.
+
+        :return ftfr: The fine tune frequency range [-ftfr, + ftfr] in GHz
+        """
+        response = self._ftfr()
+
+        ftfr = int.from_bytes(response, "big")
+
+        return ftfr * 1e-3
+
     def get_temps(self):
         """
         Returns a list of currents in degrees Celcius.

--- a/itla/itla12.py
+++ b/itla/itla12.py
@@ -323,7 +323,7 @@ class ITLA12(ITLABase):
                 )
                 raise error
 
-    def set_frequency(self, freq, ftf=None):
+    def set_frequency(self, freq):
         """Sets the frequency of the laser in TeraHertz.
 
         Has MHz resolution. Will round down.
@@ -335,34 +335,35 @@ class ITLA12(ITLABase):
         If you would like to only change the first channel frequency use
         the function `set_fcf`.
 
+        Disable the laser before calling this function.
+
         :param freq: The desired frequency setting in THz.
         :returns: None
-
         """
-
-        self.set_fcf(freq)
-        self.set_channel(1)
 
         # This does a check so this only runs if fine tuning has been turned on.
         if self.get_fine_tuning() != 0:
-            # There needs to be some delay between this and setting channel.
-            # even with some delay the CII error occurs from time to time. Fix.
-            # This delay is way longer than i would like.
-            # It would be ideal to have no sleeping necessary conditions.
-            sleep(1)
-            try:
-                self.set_fine_tuning(0)
-
-            except ExecutionError as ee:
+            # Set the fine tuning off!
+            while True:
                 try:
-                    self.nop()
+                    self.set_fine_tuning(0)
+                except ExecutionError:
+                    sleep(self.default_sleep_time)
+                except CPException:
+                    self.wait()
+                    break
+                else:
+                    break
 
-                except NOPException as nop_e:
-                    raise nop_e
+        try:
+            self.set_fcf(freq)
+        except CPException:
+            self.wait()
 
-                except CPException as cpe:
-                    print("Fine tuning takes some time. Waiting 5s.")
-                    sleep(5)
+        try:
+            self.set_channel(1)
+        except CPException:
+            self.wait()
 
     def get_fcf(self):
         """Get the currently set first channel frequency."""

--- a/itla/itla13.py
+++ b/itla/itla13.py
@@ -690,6 +690,18 @@ class ITLA13(ITLABase):
 
         return ftf * 1e-3
 
+    def get_ftf_range(self):
+        """
+        Return the maximum and minimum off grid tuning for the laser's frequency.
+
+        :return ftfr: The fine tune frequency range [-ftfr, + ftfr] in GHz
+        """
+        response = self._ftfr()
+
+        ftfr = int.from_bytes(response, "big")
+
+        return ftfr * 1e-3
+
     def get_temps(self):
         """
         Returns a list of currents in degrees Celcius.

--- a/itla/itla13.py
+++ b/itla/itla13.py
@@ -50,7 +50,7 @@ class ITLA13(ITLABase):
 
         register_files = ["registers_itla12.yaml", *register_files]
 
-        self.default_sleep_time = sleep_time
+        self.sleep_time = sleep_time
 
         super().__init__(
             serial_port, baudrate, timeout=timeout, register_files=register_files
@@ -221,8 +221,8 @@ class ITLA13(ITLABase):
             try:
                 self.nop()
             except CPException:
-                if self.default_sleep_time is not None:
-                    sleep(self.default_sleep_time)
+                if self.sleep_time is not None:
+                    sleep(self.sleep_time)
             else:
                 break
 
@@ -354,7 +354,7 @@ class ITLA13(ITLABase):
                 try:
                     self.set_fine_tuning(0)
                 except ExecutionError:
-                    sleep(self.default_sleep_time)
+                    sleep(self.sleep_time)
                 except CPException:
                     self.wait()
                     break

--- a/itla/itla13.py
+++ b/itla/itla13.py
@@ -330,7 +330,7 @@ class ITLA13(ITLABase):
                 )
                 raise error
 
-    def set_frequency(self, freq, ftf=None):
+    def set_frequency(self, freq):
         """Sets the frequency of the laser in TeraHertz.
 
         Has MHz resolution. Will round down.
@@ -342,34 +342,34 @@ class ITLA13(ITLABase):
         If you would like to only change the first channel frequency use
         the function `set_fcf`.
 
+        Disable the laser before calling this function.
+
         :param freq: The desired frequency setting in THz.
         :returns: None
-
         """
-
-        self.set_fcf(freq)
-        self.set_channel(1)
-
         # This does a check so this only runs if fine tuning has been turned on.
         if self.get_fine_tuning() != 0:
-            # There needs to be some delay between this and setting channel.
-            # even with some delay the CII error occurs from time to time. Fix.
-            # This delay is way longer than i would like.
-            # It would be ideal to have no sleeping necessary conditions.
-            sleep(1)
-            try:
-                self.set_fine_tuning(0)
-
-            except ExecutionError as ee:
+            # Set the fine tuning off!
+            while True:
                 try:
-                    self.nop()
+                    self.set_fine_tuning(0)
+                except ExecutionError:
+                    sleep(self.default_sleep_time)
+                except CPException:
+                    self.wait()
+                    break
+                else:
+                    break
 
-                except NOPException as nop_e:
-                    raise nop_e
+        try:
+            self.set_fcf(freq)
+        except CPException:
+            self.wait()
 
-                except CPException as cpe:
-                    print("Fine tuning takes some time. Waiting 5s.")
-                    sleep(5)
+        try:
+            self.set_channel(1)
+        except CPException:
+            self.wait()
 
     def get_fcf(self):
         """Get the currently set first channel frequency."""


### PR DESCRIPTION
Moving the conversation from #7 about the `set_frequency` function into it's own thread for discussion. 

> https://github.com/alexrkaufman/pytla/pull/7#issuecomment-2233513393
> re: `set_frequency` function changes
> 
> I like the goal of consolidating setting frequency into a single function.
> 
> From what I recall, and forgive me if I am incorrect because it has been a hot minute since I had access to an ITLA, the fine tune frequency register does not reset to zero when you set the frequency registers. This could cause confusion for a user where someone sets the frequency but finds that it the frequency is offset without a clear reason because the fine tune frequency was set previously. This is why the old `set_frequency` function reset the fine tune frequency to zero each time it was called.
> 
> Maybe something like this would work? The problem I see here is that it does provide for an option that leaves the fine tune frequency alone.
> 
> ```python
> def set_frequency(self, freq, ftf=0):
> 
> ... the rest of the function ...
> 
>     try:
>         self.set_fine_tuning(ftf)
>     except CPException:
>         self.wait()
>     except ExecutionError:
>         self.nop()
> ```



@f3fora you are probably working more closely with one of these lasers than I am now. I will defer to your judgement about what a typical ITLA user would expect the behavior of `set_frequency` to be. 

The goal of this project was to streamline a lot of the difficulties working with registers directly. I want to make sure that users are not surprised by the behavior of functions. I don't necessarily think how I originally set this up achieves that goal. Let me know what you think. 